### PR TITLE
A new model for inclusion (test24 by langmm)

### DIFF
--- a/test24.yaml
+++ b/test24.yaml
@@ -1,0 +1,14 @@
+model:
+  name: test24
+  args: []
+  language: executable
+  inputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes
+  outputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes


### PR DESCRIPTION
A new model has been submitted for inclusion in the repository by langmm. The model is called test24