### PR TITLE
A new model for inclusion (test44 by langmm)

### DIFF
--- a/test44.yaml
+++ b/test44.yaml
@@ -1,0 +1,14 @@
+model:
+  name: test44
+  args: []
+  language: executable
+  inputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes
+  outputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes


### PR DESCRIPTION
A new model has been submitted for inclusion in the repository by langmm. The model is called test44