### PR TITLE
A new model for inclusion (test444 by langmm)

### DIFF
--- a/test444.yaml
+++ b/test444.yaml
@@ -1,0 +1,14 @@
+model:
+  name: test444
+  args: []
+  language: executable
+  inputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes
+  outputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes


### PR DESCRIPTION
A new model has been submitted for inclusion in the repository by langmm. The model is called test444