### PR TITLE
A new model for inclusion (test42145 by langmm)

### DIFF
--- a/test42145.yaml
+++ b/test42145.yaml
@@ -1,0 +1,14 @@
+model:
+  name: test42145
+  args: []
+  language: executable
+  inputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes
+  outputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes


### PR DESCRIPTION
A new model has been submitted for inclusion in the repository by langmm. The model is called test42145