### PR TITLE
A new model for inclusion (test4236 by langmm)

### DIFF
--- a/test4236.yaml
+++ b/test4236.yaml
@@ -1,0 +1,14 @@
+model:
+  name: test4236
+  args: []
+  language: executable
+  inputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes
+  outputs:
+  - name: default
+    commtype: default
+    datatype:
+      type: bytes


### PR DESCRIPTION
A new model has been submitted for inclusion in the repository by langmm. The model is called test4236